### PR TITLE
Use `_WIN32` instead of `WIN32` to detect Windows

### DIFF
--- a/rtengine/mytime.h
+++ b/rtengine/mytime.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <profileapi.h>
 #elif defined __APPLE__
 #include <sys/time.h>
@@ -30,7 +30,7 @@ class MyTime
 {
 
 public:
-#ifndef WIN32
+#ifndef _WIN32
     timespec t;
 #else
     LONGLONG t;
@@ -47,7 +47,7 @@ public:
 
     void set ()
     {
-#ifdef WIN32
+#ifdef _WIN32
         LARGE_INTEGER ulf;
         QueryPerformanceCounter(&ulf);
         t = ulf.QuadPart;
@@ -63,7 +63,7 @@ public:
 
     int etime (const MyTime &a) const
     {
-#ifndef WIN32
+#ifndef _WIN32
         return (t.tv_sec - a.t.tv_sec) * 1000000 + (t.tv_nsec - a.t.tv_nsec) / 1000;
 #else
         return (t - a.t) * 1000 / (baseFrequency / 1000);


### PR DESCRIPTION
`WIN32` is not defined when building a 64-bit executable on Windows with Clang. `_WIN32` is the more appropriate option here.

http://web.archive.org/web/20191012035921/http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system contains a handy table/matrix of the options and why this is best.